### PR TITLE
Populate response message

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 GOOS=linux GOA
 # ---------------
 
 FROM gcr.io/distroless/static:nonroot
+LABEL org.opencontainers.image.source=https://github.com/rode/enforcer-k8s
 
 WORKDIR /
 COPY --from=builder /workspace/enforcer-k8s .

--- a/config/config.go
+++ b/config/config.go
@@ -17,18 +17,24 @@ package config
 import (
 	"errors"
 	"flag"
-	"k8s.io/client-go/util/homedir"
 	"path/filepath"
 	"strings"
+
+	"k8s.io/client-go/util/homedir"
 )
 
 type Config struct {
 	PolicyId   string
 	Tls        *TlsConfig
 	Kubernetes *KubernetesConfig
+	Rode       *RodeConfig
 	Port       int
-	RodeHost   string
 	Namespace  string
+}
+
+type RodeConfig struct {
+	Host     string
+	Insecure bool
 }
 
 type TlsConfig struct {
@@ -48,11 +54,13 @@ func Build(name string, args []string) (*Config, error) {
 	conf := &Config{
 		Tls:        &TlsConfig{},
 		Kubernetes: &KubernetesConfig{},
+		Rode:       &RodeConfig{},
 	}
 
 	flags.StringVar(&conf.PolicyId, "policy-id", "", "the ID of the rode policy to evaluate when attempting to admit a pod")
 	flags.StringVar(&conf.Tls.Secret, "tls-secret", "", "the namespaced name of the TLS secret containing the certificate / private key for the webhook TLS configuration. should be in the format ${namespace}/${name}")
-	flags.StringVar(&conf.RodeHost, "rode-host", "", "rode host")
+	flags.StringVar(&conf.Rode.Host, "rode-host", "", "rode host")
+	flags.BoolVar(&conf.Rode.Insecure, "rode-insecure", false, "when set, the connection to rode will not use TLS")
 	flags.IntVar(&conf.Port, "port", 8001, "the port to bind")
 
 	flags.BoolVar(&conf.Kubernetes.InCluster, "k8s-in-cluster", true, "when set, the enforcer will use the in-cluster k8s config")
@@ -71,7 +79,7 @@ func Build(name string, args []string) (*Config, error) {
 		return nil, errors.New("--tls-secret is required")
 	}
 
-	if conf.RodeHost == "" {
+	if conf.Rode.Host == "" {
 		return nil, errors.New("--rode-host is required")
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -24,13 +24,14 @@ import (
 )
 
 type Config struct {
-	Debug      bool
-	PolicyId   string
-	Tls        *TlsConfig
-	Kubernetes *KubernetesConfig
-	Rode       *RodeConfig
-	Port       int
-	Namespace  string
+	Debug                      bool
+	RegistryInsecureSkipVerify bool
+	Kubernetes                 *KubernetesConfig
+	Namespace                  string
+	PolicyId                   string
+	Port                       int
+	Rode                       *RodeConfig
+	Tls                        *TlsConfig
 }
 
 type RodeConfig struct {
@@ -62,6 +63,7 @@ func Build(name string, args []string) (*Config, error) {
 	flags.StringVar(&conf.Tls.Secret, "tls-secret", "", "the namespaced name of the TLS secret containing the certificate / private key for the webhook TLS configuration. should be in the format ${namespace}/${name}")
 	flags.StringVar(&conf.Rode.Host, "rode-host", "", "rode host")
 	flags.BoolVar(&conf.Rode.Insecure, "rode-insecure", false, "when set, the connection to rode will not use TLS")
+	flags.BoolVar(&conf.RegistryInsecureSkipVerify, "registry-insecure-skip-verify", false, "when set, TLS connections to container registries will be insecure")
 	flags.BoolVar(&conf.Debug, "debug", false, "when set, debug mode will be enabled")
 	flags.IntVar(&conf.Port, "port", 8001, "the port to bind")
 

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,7 @@ import (
 )
 
 type Config struct {
+	Debug      bool
 	PolicyId   string
 	Tls        *TlsConfig
 	Kubernetes *KubernetesConfig
@@ -61,6 +62,7 @@ func Build(name string, args []string) (*Config, error) {
 	flags.StringVar(&conf.Tls.Secret, "tls-secret", "", "the namespaced name of the TLS secret containing the certificate / private key for the webhook TLS configuration. should be in the format ${namespace}/${name}")
 	flags.StringVar(&conf.Rode.Host, "rode-host", "", "rode host")
 	flags.BoolVar(&conf.Rode.Insecure, "rode-insecure", false, "when set, the connection to rode will not use TLS")
+	flags.BoolVar(&conf.Debug, "debug", false, "when set, debug mode will be enabled")
 	flags.IntVar(&conf.Port, "port", 8001, "the port to bind")
 
 	flags.BoolVar(&conf.Kubernetes.InCluster, "k8s-in-cluster", true, "when set, the enforcer will use the in-cluster k8s config")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -50,8 +50,10 @@ var _ = DescribeTable("config",
 				ConfigFile: filepath.Join(homedir.HomeDir(), ".kube", "config"),
 			},
 			PolicyId: "foo",
-			RodeHost: "localhost:50051",
-			Port:     8001,
+			Rode: &RodeConfig{
+				Host: "localhost:50051",
+			},
+			Port: 8001,
 		},
 	}),
 	Entry("missing policy ID", entry{

--- a/enforcer/enforcer.go
+++ b/enforcer/enforcer.go
@@ -160,7 +160,7 @@ func (e *Enforcer) getPolicyName(log *zap.Logger) string {
 }
 
 func handleError(log *zap.Logger, response *v1.AdmissionResponse, message string, err error) {
-	log.Error("message", zap.Error(err))
+	log.Error(message, zap.Error(err))
 
 	response.Result = &metav1.Status{
 		Message: fmt.Sprintf("%s: %s", message, err),

--- a/enforcer/enforcer.go
+++ b/enforcer/enforcer.go
@@ -78,7 +78,11 @@ func (e *Enforcer) Enforce(admissionReview *v1.AdmissionReview) (*v1.AdmissionRe
 		return response, nil
 	}
 
-	for _, container := range pod.Spec.Containers {
+	var allContainers []corev1.Container
+	allContainers = append(allContainers, pod.Spec.InitContainers...)
+	allContainers = append(allContainers, pod.Spec.Containers...)
+
+	for _, container := range allContainers {
 		if pass := e.evaluatePolicy(log, response, container.Image); !pass {
 			return response, nil
 		}

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
 	"os/signal"
@@ -43,53 +44,53 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-func webhook(log *zap.Logger, k8sEnforcer *enforcer.Enforcer) func(w http.ResponseWriter, r *http.Request) {
+func webhook(logger *zap.Logger, k8sEnforcer *enforcer.Enforcer) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		log.Info("request received")
+		logger.Info("request received")
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
-			log.Error("Error reading response body", zap.Error(err))
+			logger.Error("Error reading response body", zap.Error(err))
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
 
 		if contentType := r.Header.Get("Content-Type"); contentType != "application/json" {
-			log.Error("Unexpected content type", zap.String("contentType", contentType))
+			logger.Error("Unexpected content type", zap.String("contentType", contentType))
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
 
 		admissionReview := &v1.AdmissionReview{}
 		if err := json.Unmarshal(body, admissionReview); err != nil {
-			log.Error("Unable to deserialize request body: %s", zap.Error(err))
+			logger.Error("Unable to deserialize request body: %s", zap.Error(err))
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
 
 		response, err := k8sEnforcer.Enforce(admissionReview)
 		if err != nil {
-			log.Error("error building admission response", zap.Error(err))
+			logger.Error("error building admission response", zap.Error(err))
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 
 		admissionReview.Response = response
 
-		log.Info("raw response", zap.Any("response", admissionReview.Response))
+		logger.Info("raw response", zap.Any("response", admissionReview.Response))
 		responseBytes, err := json.Marshal(admissionReview)
 		if err != nil {
-			log.Error("error serializing response", zap.Error(err))
+			logger.Error("error serializing response", zap.Error(err))
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 
 		w.Header().Set("Content-Type", "application/json")
 		if _, err := w.Write(responseBytes); err != nil {
-			log.Error("error writing response", zap.Error(err))
+			logger.Error("error writing response", zap.Error(err))
 			return
 		}
 
-		log.Info("successful request")
+		logger.Info("successful request")
 	}
 }
 
@@ -97,7 +98,7 @@ func healthz(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-func newK8sClient(log *zap.Logger, kubernetesConfig *config.KubernetesConfig) *kubernetes.Clientset {
+func newK8sClient(logger *zap.Logger, kubernetesConfig *config.KubernetesConfig) *kubernetes.Clientset {
 	var (
 		clusterConfig *rest.Config
 		err           error
@@ -106,7 +107,7 @@ func newK8sClient(log *zap.Logger, kubernetesConfig *config.KubernetesConfig) *k
 	if kubernetesConfig.InCluster {
 		clusterConfig, err = rest.InClusterConfig()
 		if err != nil {
-			log.Fatal("Failed to get cluster config", zap.Error(err))
+			logger.Fatal("Failed to get cluster config", zap.Error(err))
 		}
 	} else {
 		clusterConfig, err = clientcmd.BuildConfigFromFlags("", kubernetesConfig.ConfigFile)
@@ -114,13 +115,13 @@ func newK8sClient(log *zap.Logger, kubernetesConfig *config.KubernetesConfig) *k
 
 	client, err := kubernetes.NewForConfig(clusterConfig)
 	if err != nil {
-		log.Fatal("Error creating kubernetes client", zap.Error(err))
+		logger.Fatal("Error creating kubernetes client", zap.Error(err))
 	}
 
 	return client
 }
 
-func newRodeClient(log *zap.Logger, conf *config.Config) (*grpc.ClientConn, rode.RodeClient) {
+func newRodeClient(logger *zap.Logger, conf *config.Config) (*grpc.ClientConn, rode.RodeClient) {
 	dialOptions := []grpc.DialOption{
 		grpc.WithBlock(),
 	}
@@ -134,31 +135,31 @@ func newRodeClient(log *zap.Logger, conf *config.Config) (*grpc.ClientConn, rode
 	defer cancel()
 	conn, err := grpc.DialContext(ctx, conf.Rode.Host, dialOptions...)
 	if err != nil {
-		log.Fatal("failed to establish grpc connection to Rode", zap.Error(err))
+		logger.Fatal("failed to establish grpc connection to Rode", zap.Error(err))
 	}
 
 	return conn, rode.NewRodeClient(conn)
 }
 
-func createTlsConfig(log *zap.Logger, conf *config.Config, client *kubernetes.Clientset) *tls.Config {
+func createTlsConfig(logger *zap.Logger, conf *config.Config, client *kubernetes.Clientset) *tls.Config {
 	secret, err := client.CoreV1().Secrets(conf.Tls.Namespace).Get(context.Background(), conf.Tls.Name, metav1.GetOptions{})
 	if err != nil {
-		log.Fatal("Failed to find secret", zap.Error(err), zap.String("secret", conf.Tls.Secret))
+		logger.Fatal("Failed to find secret", zap.Error(err), zap.String("secret", conf.Tls.Secret))
 	}
 
 	cert, ok := secret.Data["tls.crt"]
 	if !ok {
-		log.Fatal("Secret missing tls.crt", zap.String("secret", conf.Tls.Secret))
+		logger.Fatal("Secret missing tls.crt", zap.String("secret", conf.Tls.Secret))
 	}
 
 	key, ok := secret.Data["tls.key"]
 	if !ok {
-		log.Fatal("Secret missing tls.key", zap.String("secret", conf.Tls.Secret))
+		logger.Fatal("Secret missing tls.key", zap.String("secret", conf.Tls.Secret))
 	}
 
 	certificate, err := tls.X509KeyPair(cert, key)
 	if err != nil {
-		log.Fatal("Error loading key pair", zap.Error(err))
+		logger.Fatal("Error loading key pair", zap.Error(err))
 	}
 
 	return &tls.Config{
@@ -166,46 +167,57 @@ func createTlsConfig(log *zap.Logger, conf *config.Config, client *kubernetes.Cl
 	}
 }
 
-func main() {
-	log, _ := zap.NewDevelopment()
-
-	conf, err := config.Build(os.Args[0], os.Args[1:])
-	if err != nil {
-		log.Fatal("failed to build config", zap.Error(err))
+func createLogger(debug bool) (*zap.Logger, error) {
+	if debug {
+		return zap.NewDevelopment()
 	}
 
-	client := newK8sClient(log, conf.Kubernetes)
+	return zap.NewProduction()
+}
 
-	conn, rodeClient := newRodeClient(log, conf)
+func main() {
+	conf, err := config.Build(os.Args[0], os.Args[1:])
+	if err != nil {
+		log.Fatalf("failed to build config: %s", err)
+	}
+
+	logger, err := createLogger(conf.Debug)
+	if err != nil {
+		log.Fatalf("failed to create logger:: %s", err)
+	}
+
+	client := newK8sClient(logger, conf.Kubernetes)
+
+	conn, rodeClient := newRodeClient(logger, conf)
 	defer conn.Close()
 
 	k8sEnforcer := enforcer.NewEnforcer(
-		log.Named("Enforcer"),
+		logger.Named("Enforcer"),
 		conf,
 		rodeClient,
 	)
 
-	http.HandleFunc("/", webhook(log, k8sEnforcer))
+	http.HandleFunc("/", webhook(logger, k8sEnforcer))
 	http.HandleFunc("/healthz", healthz)
 
 	server := &http.Server{
 		Addr:      fmt.Sprintf(":%d", conf.Port),
-		TLSConfig: createTlsConfig(log, conf, client),
+		TLSConfig: createTlsConfig(logger, conf, client),
 	}
 
 	go func() {
 		if err := server.ListenAndServeTLS("", ""); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			log.Fatal("error starting server", zap.Error(err))
+			logger.Fatal("error starting server", zap.Error(err))
 		}
 	}()
 
-	log.Info("listening", zap.Int("port", conf.Port))
+	logger.Info("listening", zap.Int("port", conf.Port))
 
 	s := make(chan os.Signal, 1)
 	signal.Notify(s, syscall.SIGINT, syscall.SIGTERM)
 
 	<-s
 
-	log.Info("Shutting down...")
+	logger.Info("Shutting down...")
 	server.Shutdown(context.Background())
 }


### PR DESCRIPTION
The enforcer should now return an message when an image fails policy:

> Error from server: admission webhook "k8s-enforcer.rode.io" denied the request: container image "harbor.localhost/rode-demo/nginx:latest" failed the Rode policy "Sample Harbor Policy" (id: 38e62c17-750a-43e3-ad54-335571d340c4)

or when an error occurs:

> Error from server: admission webhook "k8s-enforcer.rode.io" denied the request: error evaluating policy: rpc error: code = Unavailable desc = connection closed

Also includes some smaller changes:

- new flags:
   - `rode-insecure` for connecting to Rode without transport security 
   - `debug` flag to configure log level
   - `registry-insecure-skip-verify` to control whether TLS is verified when the enforcer fetches image manifests from a registry
- refactor server TLS config to avoid writing cert and key to disk 
- check init containers against policy  (closes #7)
- add source label to Docker image
- handle images from Docker Hub that don't include registry url or are the default `library` namespace/organization

This will require some changes to the Helm chart to allow for configuring the new flags, which I can do after this is merged and released. 