### PR TITLE
Handle image pull secrets

### DIFF
--- a/enforcer/enforcer_test.go
+++ b/enforcer/enforcer_test.go
@@ -57,6 +57,7 @@ var _ = Describe("Enforcer", func() {
 		enforcer = NewEnforcer(
 			logger,
 			conf,
+			nil,
 			mockRode,
 		)
 		ctx = context.Background()

--- a/go.sum
+++ b/go.sum
@@ -158,6 +158,7 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/evanphx/json-patch v4.9.0+incompatible h1:kLcOMZeuLAJvL2BPWLMIj5oaZQobrkAqrL+WFZwQses=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fernet/fernet-go v0.0.0-20180830025343-9eac43b88a5e/go.mod h1:2H9hjfbpSMHwY503FclkV/lZTBh2YlOmLLSda12uL8c=
@@ -1021,6 +1022,7 @@ k8s.io/klog/v2 v2.4.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/klog/v2 v2.8.0 h1:Q3gmuM9hKEjefWFFYF0Mat+YyFJvsUyYuwyNNJ5C9Ts=
 k8s.io/klog/v2 v2.8.0/go.mod h1:hy9LJ/NvuK+iVyP4Ehqva4HxZG/oXyIS3n3Jmire4Ec=
 k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6/go.mod h1:UuqjUnNftUyPE5H64/qeyjQoUZhGpeFDVdxjTeEVN2o=
+k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7 h1:vEx13qjvaZ4yfObSSXW7BrMc/KQBBT/Jyee8XtLf4x0=
 k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7/go.mod h1:wXW5VT87nVfh/iLV8FpR2uDvrFyomxbtb1KivDbvPTE=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920 h1:CbnUZsM497iRC5QMVkHwyl8s2tB3g7yaSHkYPkpgelw=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=

--- a/main.go
+++ b/main.go
@@ -194,6 +194,7 @@ func main() {
 	k8sEnforcer := enforcer.NewEnforcer(
 		logger.Named("Enforcer"),
 		conf,
+		client,
 		rodeClient,
 	)
 


### PR DESCRIPTION
Updates the enforcer to grab any image pull secrets and send them when the auth key in the secret matches the registry.

I've been testing with the demo by leaving the Harbor project set to private and doing the following:

```shell
kubectl create ns test
kubectl label ns test enforcer-k8s=enabled
kubectl -n test create secret docker-registry harbor --docker-server=https://harbor.localhost/rode-demo --docker-username=admin --docker-password=$HARBOR_PASSWORD
kubectl apply -f pod.yaml
``` 

where `pod.yaml` is

```
apiVersion: v1
kind: Pod
metadata:
  labels:
    run: nginx
  name: nginx
  namespace: test
spec:
  containers:
    - image: harbor.localhost/rode-demo/nginx:latest
      name: nginx
      resources: {}
  imagePullSecrets:
    - name: "harbor"
```